### PR TITLE
docs: update npm publish workflow and instructions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@cmwen'
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org/'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -32,14 +31,7 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - name: Configure GitHub Package Registry
-        run: |
-          echo "@cmwen:registry=https://npm.pkg.github.com" > .npmrc
-          echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" >> .npmrc
+      - name: Publish to npm
+        run: pnpm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to GitHub Packages
-        run: pnpm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.2.0] - 2025-08-10
+
+### Added
+
+- GitHub Actions workflow for publishing to npm on tag push
+- Updated README with npm install and publish instructions
+- Instructions for setting up npm token and manual publish
+
+### Changed
+
+- README improvements and clarified publishing steps
+
+---
+
 ## [0.1.0] - 2025-08-09
 
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Min Wen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -17,15 +17,8 @@ A minimalist, file-based knowledge base server designed to be operated programma
 
 ## Installation
 
-Zero native deps (no compilers, no SDKs). To install from GitHub Packages, authenticate first:
 
-```bash
-# Create or edit ~/.npmrc
-echo "@cmwen:registry=https://npm.pkg.github.com" >> ~/.npmrc
-# You'll need a GitHub personal access token with `read:packages` scope
-```
-
-Then install the package:
+Zero native deps (no compilers, no SDKs). To install from npm:
 
 ```bash
 pnpm add @cmwen/min-kb-mcp
@@ -36,6 +29,38 @@ Or run directly with:
 ```bash
 npx @cmwen/min-kb-mcp start --kb my-notes
 ```
+
+## Publishing to npm
+
+To publish a new version:
+
+1. Bump the version in `package.json`.
+2. Commit and push your changes.
+3. Create a new tag (e.g. `v1.2.3`) and push it:
+   ```bash
+   git tag v1.2.3
+   git push origin v1.2.3
+   ```
+4. The GitHub Actions workflow will automatically build and publish to npm if you have set the `NPM_TOKEN` secret in your repository.
+
+### Setting up your npm token
+
+1. Get your npm token by running:
+   ```bash
+   npm token create
+   ```
+2. Add it to your GitHub repository secrets as `NPM_TOKEN`.
+
+### Manual publish (local)
+
+If you want to publish manually:
+
+```bash
+pnpm run build
+pnpm publish --access public
+```
+
+Make sure your npm user has access to the `@cmwen` scope.
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmwen/min-kb-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A minimalist, file-based knowledge base server (MCP) for LLMs.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to publish to npm and revises the README with installation and publishing instructions for npm. It also provides setup steps for the npm token and manual publishing instructions.